### PR TITLE
Enables auto-comments

### DIFF
--- a/nearley.tmPreferences
+++ b/nearley.tmPreferences
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>name</key>
+	<string>Comments</string>
+	<key>scope</key>
+	<string>source.ne</string>
+	<key>settings</key>
+	<dict>
+		<key>shellVariables</key>
+		<array>
+			<dict>
+				<key>name</key>
+				<string>TM_COMMENT_START</string>
+				<key>value</key>
+				<string># </string>
+			</dict>
+		</array>
+	</dict>
+	<key>uuid</key>
+	<string>3416031c-68af-48cb-a8fd-967857eb50d0</string>
+</dict>
+</plist>


### PR DESCRIPTION
Auto-comments are very nice to have, and this got them working on my machine.

It's more or less a copy/paste job from other repos, so things like the `uuid` I suppose could be changed (I didn't look into the meaning or importance of that key/value pair).